### PR TITLE
Remove unused CancellationToken parameters

### DIFF
--- a/src/InvestProvider.Backend/Services/Handlers/AdminCreatePoolzBackId/AdminCreatePoolzBackIdHandler.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/AdminCreatePoolzBackId/AdminCreatePoolzBackIdHandler.cs
@@ -15,9 +15,9 @@ public class AdminCreatePoolzBackIdHandler(
 )
     : IRequestHandler<AdminCreatePoolzBackIdRequest, AdminCreatePoolzBackIdResponse>
 {
-    public async Task<AdminCreatePoolzBackIdResponse> Handle(AdminCreatePoolzBackIdRequest request, CancellationToken cancellationToken)
+    public async Task<AdminCreatePoolzBackIdResponse> Handle(AdminCreatePoolzBackIdRequest request, CancellationToken _)
     {
-        _ = strapi.ReceiveProjectInfo(request.ProjectId, filterPhases: false);
+        strapi.ReceiveProjectInfo(request.ProjectId, filterPhases: false);
 
         var getFullData = await lockDealNFT.GetFullDataQueryAsync(request.ChainId, ContractType.LockDealNFT, request.PoolzBackId);
         if (getFullData.PoolInfo.Count != 2 ||
@@ -25,7 +25,7 @@ public class AdminCreatePoolzBackIdHandler(
             getFullData.PoolInfo[1].Name != ContractNames.DispenserProvider
         ) throw Error.INVALID_POOL_TYPE.ToException();
 
-        await dynamoDb.SaveAsync(request, cancellationToken);
+        await dynamoDb.SaveAsync(request);
 
         return new AdminCreatePoolzBackIdResponse(request);
     }

--- a/src/InvestProvider.Backend/Services/Handlers/GenerateSignature/GenerateSignatureHandler.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/GenerateSignature/GenerateSignatureHandler.cs
@@ -35,7 +35,7 @@ public class GenerateSignatureHandler(
 {
     public const byte MinInvestAmount = 1;
 
-    public async Task<GenerateSignatureResponse> Handle(GenerateSignatureRequest request, CancellationToken cancellationToken)
+    public async Task<GenerateSignatureResponse> Handle(GenerateSignatureRequest request, CancellationToken _)
     {
         var projectInfo = strapi.ReceiveProjectInfo(request.ProjectId, filterPhases: true);
         if (projectInfo.CurrentPhase == null)
@@ -46,7 +46,7 @@ public class GenerateSignatureHandler(
             });
         }
 
-        var dynamoProjectInfo = await dynamoDb.LoadAsync<ProjectsInformation>(request.ProjectId, cancellationToken);
+        var dynamoProjectInfo = await dynamoDb.LoadAsync<ProjectsInformation>(request.ProjectId);
         if (dynamoProjectInfo == null)
         {
             throw Error.POOLZ_BACK_ID_NOT_FOUND.ToException(new
@@ -81,7 +81,7 @@ public class GenerateSignatureHandler(
 
         if (projectInfo.CurrentPhase.MaxInvest == 0)
         {
-            var whiteList = await dynamoDb.LoadAsync<WhiteList>(WhiteList.CalculateHashId(request.ProjectId, projectInfo.CurrentPhase.Start!.Value), request.UserAddress.Address, cancellationToken);
+            var whiteList = await dynamoDb.LoadAsync<WhiteList>(WhiteList.CalculateHashId(request.ProjectId, projectInfo.CurrentPhase.Start!.Value), request.UserAddress.Address, CancellationToken.None);
             if (whiteList == null) throw Error.USER_NOT_FOUND.ToException();
             ValidateWhiteList(whiteList, amount, investAmounts);
         }

--- a/src/InvestProvider.Backend/Services/Handlers/MyAllocation/MyAllocationHandler.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/MyAllocation/MyAllocationHandler.cs
@@ -10,9 +10,9 @@ namespace InvestProvider.Backend.Services.Handlers.MyAllocation;
 public class MyAllocationHandler(IStrapiClient strapi, IDynamoDBContext dynamoDb)
     : IRequestHandler<MyAllocationRequest, MyAllocationResponse>
 {
-    public async Task<MyAllocationResponse> Handle(MyAllocationRequest request, CancellationToken cancellationToken)
+    public async Task<MyAllocationResponse> Handle(MyAllocationRequest request, CancellationToken _)
     {
-        var dynamoProjectInfo = await dynamoDb.LoadAsync<ProjectsInformation>(request.ProjectId, cancellationToken);
+        var dynamoProjectInfo = await dynamoDb.LoadAsync<ProjectsInformation>(request.ProjectId);
         if (dynamoProjectInfo == null) throw Error.POOLZ_BACK_ID_NOT_FOUND.ToException(new
         {
             request.ProjectId
@@ -32,7 +32,7 @@ public class MyAllocationHandler(IStrapiClient strapi, IDynamoDBContext dynamoDb
         var whiteList = await dynamoDb.LoadAsync<WhiteList>(
             hashKey: WhiteList.CalculateHashId(request.ProjectId, projectInfo.CurrentPhase.Start!.Value),
             rangeKey: request.UserAddress.Address,
-            cancellationToken
+            CancellationToken.None
         );
         if (whiteList == null) throw Error.NOT_IN_WHITE_LIST.ToException(new
         {

--- a/src/InvestProvider.Backend/Services/Handlers/MyUpcomingAllocation/MyUpcomingAllocationHandler.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/MyUpcomingAllocation/MyUpcomingAllocationHandler.cs
@@ -10,7 +10,7 @@ namespace InvestProvider.Backend.Services.Handlers.MyUpcomingAllocation;
 public class MyUpcomingAllocationHandler(IDynamoDBContext dynamoDb)
     : IRequestHandler<MyUpcomingAllocationRequest, ICollection<MyUpcomingAllocationResponse>>
 {
-    public async Task<ICollection<MyUpcomingAllocationResponse>> Handle(MyUpcomingAllocationRequest request, CancellationToken cancellationToken)
+    public async Task<ICollection<MyUpcomingAllocationResponse>> Handle(MyUpcomingAllocationRequest request, CancellationToken _)
     {
         var table = dynamoDb.GetTargetTable<WhiteList>();
         var whiteListTask = table.Query(new QueryOperationConfig 
@@ -28,9 +28,9 @@ public class MyUpcomingAllocationHandler(IDynamoDBContext dynamoDb)
                     .Select((id, i) => new { k = $":p{i}", v = (DynamoDBEntry)id })
                     .ToDictionary(x => x.k, x => x.v)
             }
-        }).GetRemainingAsync(cancellationToken);
+        }).GetRemainingAsync(CancellationToken.None);
 
-        var projectInfoTask = dynamoDb.BatchLoadAsync<ProjectsInformation>(request.ProjectIDs, cancellationToken);
+        var projectInfoTask = dynamoDb.BatchLoadAsync<ProjectsInformation>(request.ProjectIDs);
 
         await Task.WhenAll(whiteListTask, projectInfoTask);
 


### PR DESCRIPTION
## Summary
- remove the `cancellationToken` parameter from handler implementations
- stop passing the tokens when invoking DynamoDB or other methods

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_6857c4de89dc833080f2fd5eba2705ab