### PR TITLE
Refactor lambda to inject mediator

### DIFF
--- a/src/InvestProvider.Backend/InvestProviderLambda.cs
+++ b/src/InvestProvider.Backend/InvestProviderLambda.cs
@@ -9,17 +9,16 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace InvestProvider.Backend;
 
-public class InvestProviderLambda(IServiceProvider serviceProvider)
+public class InvestProviderLambda(IMediator mediator)
 {
-    public InvestProviderLambda() : this(DefaultServiceProvider.Build()) { }
+    public InvestProviderLambda() : this(
+        DefaultServiceProvider.Build().GetRequiredService<IMediator>()) { }
 
     public async Task<LambdaResponse> RunAsync(LambdaRequest request)
     {
         try
         {
-            var response = await serviceProvider
-                .GetRequiredService<IMediator>()
-                .Send(request.HandlerRequest);
+            var response = await mediator.Send(request.HandlerRequest);
             return new LambdaResponse(response);
         }
         catch (ValidationException ex)


### PR DESCRIPTION
## Summary
- inject `IMediator` directly into `InvestProviderLambda`
- simplify call to MediatR in the lambda entry point

## Testing
- `dotnet restore InvestProvider.Backend.sln`
- `dotnet build InvestProvider.Backend.sln --configuration Release --no-restore`
- `dotnet test tests/InvestProvider.Backend.Tests/InvestProvider.Backend.Tests.csproj --configuration Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6857c62282308330ba329a3945f51d31