### PR TITLE
Refactor MyAllocationValidator rules

### DIFF
--- a/src/InvestProvider.Backend/Services/Handlers/AdminCreatePoolzBackId/AdminCreatePoolzBackIdValidator.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/AdminCreatePoolzBackId/AdminCreatePoolzBackIdValidator.cs
@@ -23,10 +23,9 @@ public class AdminCreatePoolzBackIdValidator : AbstractValidator<AdminCreatePool
         ClassLevelCascadeMode = CascadeMode.Stop;
 
         RuleFor(x => x)
+            .Cascade(CascadeMode.Stop)
             .Must(NotNullCurrentPhase)
-            .WithError(Error.NOT_FOUND_ACTIVE_PHASE, x => new { x.ProjectId });
-
-        RuleFor(x => x)
+            .WithError(Error.NOT_FOUND_ACTIVE_PHASE, x => new { x.ProjectId })
             .MustAsync(async (x, _) =>
             {
                 var data = await _lockDealNFT.GetFullDataQueryAsync(x.ChainId, ContractType.LockDealNFT, x.PoolzBackId);

--- a/src/InvestProvider.Backend/Services/Handlers/AdminWriteAllocation/AdminWriteAllocationValidator.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/AdminWriteAllocation/AdminWriteAllocationValidator.cs
@@ -20,21 +20,15 @@ public class AdminWriteAllocationValidator : AbstractValidator<AdminWriteAllocat
         ClassLevelCascadeMode = CascadeMode.Stop;
 
         RuleFor(x => x)
-            .MustAsync(NotNullProjectsInformationAsync)
-            .WithError(Error.POOLZ_BACK_ID_NOT_FOUND, x => new { x.ProjectId });
-
-        RuleFor(x => x)
-            .Must(NotNullCurrentPhase)
-            .WithError(Error.NOT_FOUND_ACTIVE_PHASE, x => new { x.ProjectId });
-
-        RuleFor(x => x)
             .Cascade(CascadeMode.Stop)
+            .MustAsync(NotNullProjectsInformationAsync)
+            .WithError(Error.POOLZ_BACK_ID_NOT_FOUND, x => new { x.ProjectId })
+            .Must(NotNullCurrentPhase)
+            .WithError(Error.NOT_FOUND_ACTIVE_PHASE, x => new { x.ProjectId })
             .Must(SetPhase)
             .WithError(Error.PHASE_IN_PROJECT_NOT_FOUND, x => new { x.ProjectId, x.PhaseId })
             .Must(x => DateTime.UtcNow < x.Phase.Finish)
-            .WithError(Error.PHASE_FINISHED, x => new { EndTime = x.Phase.Finish, NowTime = DateTime.UtcNow });
-
-        RuleFor(x => x)
+            .WithError(Error.PHASE_FINISHED, x => new { EndTime = x.Phase.Finish, NowTime = DateTime.UtcNow })
             .Must(x => x.Phase.MaxInvest == 0)
             .WithError(Error.PHASE_IS_NOT_WHITELIST);
     }

--- a/src/InvestProvider.Backend/Services/Handlers/GenerateSignature/GenerateSignatureValidator.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/GenerateSignature/GenerateSignatureValidator.cs
@@ -43,24 +43,18 @@ public partial class GenerateSignatureRequestValidator : AbstractValidator<Gener
         RuleFor(x => x.WeiAmount).NotNull().NotEmpty();
 
         RuleFor(x => x)
+            .Cascade(CascadeMode.Stop)
             .Must(NotNullCurrentPhase)
-            .WithError(Error.NOT_FOUND_ACTIVE_PHASE, x => new { x.ProjectId });
-
-        RuleFor(x => x)
+            .WithError(Error.NOT_FOUND_ACTIVE_PHASE, x => new { x.ProjectId })
             .MustAsync(NotNullProjectsInformationAsync)
-            .WithError(Error.POOLZ_BACK_ID_NOT_FOUND, x => new { x.ProjectId });
-
-        RuleFor(x => x)
+            .WithError(Error.POOLZ_BACK_ID_NOT_FOUND, x => new { x.ProjectId })
             .MustAsync(MustMoreThanAllowedMinimumAsync)
             .WithError(Error.INVEST_AMOUNT_IS_LESS_THAN_ALLOWED, x => new
             {
                 UserAmount = x.Amount,
                 MinInvestAmount = UnitConversion.Convert.FromWei(_minInvestAmount, x.TokenDecimals)
-            });
-
-        RuleFor(x => x)
-            .CustomAsync(SetUserInvestmentsAsync)
-            .WhenAsync((x, _) => Task.FromResult(true));
+            })
+            .CustomAsync(SetUserInvestmentsAsync);
 
         RuleFor(x => x)
             .Cascade(CascadeMode.Stop)

--- a/src/InvestProvider.Backend/Services/Handlers/MyAllocation/MyAllocationValidator.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/MyAllocation/MyAllocationValidator.cs
@@ -17,27 +17,20 @@ public class MyAllocationValidator : AbstractValidator<MyAllocationRequest>
         _strapi = strapi;
         _dynamoDb = dynamoDb;
 
-        RuleFor(x => x)
-            .MustAsync(NotNullProjectsInformationAsync)
-            .WithError(Error.POOLZ_BACK_ID_NOT_FOUND, x => new { x.ProjectId });
-
-        RuleFor(x => x)
-            .Must(NotNullCurrentPhase)
-            .WithError(Error.NOT_FOUND_ACTIVE_PHASE, x => new { x.ProjectId });
+        ClassLevelCascadeMode = CascadeMode.Stop;
 
         RuleFor(x => x)
             .Cascade(CascadeMode.Stop)
+            .MustAsync(NotNullProjectsInformationAsync)
+            .WithError(Error.POOLZ_BACK_ID_NOT_FOUND, x => new { x.ProjectId })
+            .Must(NotNullCurrentPhase)
+            .WithError(Error.NOT_FOUND_ACTIVE_PHASE, x => new { x.ProjectId })
             .Must(SetPhase)
             .WithError(Error.PHASE_IN_PROJECT_NOT_FOUND, x => new { x.ProjectId, x.PhaseId })
             .Must(x => DateTime.UtcNow < x.Phase.Finish)
-            .WithError(Error.PHASE_FINISHED, x => new { EndTime = x.Phase.Finish, NowTime = DateTime.UtcNow });
-
-        RuleFor(x => x)
+            .WithError(Error.PHASE_FINISHED, x => new { EndTime = x.Phase.Finish, NowTime = DateTime.UtcNow })
             .Must(x => x.Phase.MaxInvest == 0)
-            .WithError(Error.PHASE_IS_NOT_WHITELIST);
-
-        RuleFor(x => x)
-            .Cascade(CascadeMode.Stop)
+            .WithError(Error.PHASE_IS_NOT_WHITELIST)
             .MustAsync(NotNullWhiteListAsync)
             .WithError(Error.NOT_IN_WHITE_LIST, x => new { x.ProjectId, PhaseId = x.StrapiProjectInfo.CurrentPhase!.Id, UserAddress = x.UserAddress.Address });
     }


### PR DESCRIPTION
## Summary
- avoid repeated `RuleFor(x => x)` calls in `MyAllocationValidator`
- add `ClassLevelCascadeMode` to stop further validation once a rule fails

## Testing
- `dotnet test tests/InvestProvider.Backend.Tests/InvestProvider.Backend.Tests.csproj -l trx`

------
https://chatgpt.com/codex/tasks/task_e_6857d78e4ef483309d3eaa30c63018de