### PR TITLE
Fix SonarCloud coverage path

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -53,8 +53,8 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
         run: |
-          ./.sonar/scanner/dotnet-sonarscanner begin /k:"The-Poolz_InvestProvider.Backend" /o:"the-poolz" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.cobertura.reportsPaths="**/coverage.cobertura.xml" /d:sonar.scanner.scanAll=false
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"The-Poolz_InvestProvider.Backend" /o:"the-poolz" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.cobertura.reportsPaths="TestResults/**/coverage.cobertura.xml" /d:sonar.cs.vstest.reportsPaths="TestResults/**/*.trx" /d:sonar.scanner.scanAll=false
           dotnet restore
           dotnet build --no-restore
-          dotnet test --no-build --collect:"XPlat Code Coverage"
+          dotnet test --no-build --collect:"XPlat Code Coverage" --logger trx --results-directory TestResults
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
## Summary
- adjust GitHub workflow so SonarCloud can find coverage and test reports

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857df44aad8833095cc6d09bd658a8f