### PR TITLE
Update coverage settings for SonarCloud

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -53,8 +53,8 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
         run: |
-          ./.sonar/scanner/dotnet-sonarscanner begin /k:"The-Poolz_InvestProvider.Backend" /o:"the-poolz" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.cobertura.reportsPaths="TestResults/**/coverage.cobertura.xml" /d:sonar.cs.vstest.reportsPaths="TestResults/**/*.trx" /d:sonar.scanner.scanAll=false
+          ./.sonar/scanner/dotnet-sonarscanner begin /k:"The-Poolz_InvestProvider.Backend" /o:"the-poolz" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="TestResults/**/coverage.opencover.xml" /d:sonar.cs.vstest.reportsPaths="TestResults/**/*.trx" /d:sonar.scanner.scanAll=false
           dotnet restore
           dotnet build --no-restore
-          dotnet test --no-build --collect:"XPlat Code Coverage" --logger trx --results-directory TestResults
+          dotnet test --no-build --results-directory TestResults --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --logger trx
           ./.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
## Summary
- configure CI pipeline to publish opencover coverage reports
- update `dotnet test` command accordingly

## Testing
- `dotnet test tests/InvestProvider.Backend.Tests/InvestProvider.Backend.Tests.csproj --results-directory TestResults --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover --logger trx`

------
https://chatgpt.com/codex/tasks/task_e_6857e11d5dec8330a412891905edad4c