### PR TITLE
Increase handler test coverage

### DIFF
--- a/tests/InvestProvider.Backend.Tests/Handlers/AdminGetAllocationHandlerTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Handlers/AdminGetAllocationHandlerTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.DynamoDBv2.DataModel;
+using Moq;
+using Xunit;
+using InvestProvider.Backend.Services.DynamoDb.Models;
+using InvestProvider.Backend.Services.Handlers.AdminGetAllocation;
+using InvestProvider.Backend.Services.Handlers.AdminGetAllocation.Models;
+using InvestProvider.Backend.Services.Handlers.AdminWriteAllocation.Models;
+using InvestProvider.Backend.Services.Strapi;
+using Net.Web3.EthereumWallet;
+
+namespace InvestProvider.Backend.Tests.Handlers;
+
+public class AdminGetAllocationHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsWhiteLists_ForAllPhases()
+    {
+        var phase1 = TestHelpers.CreatePhase("1", DateTime.UtcNow.AddHours(-2), DateTime.UtcNow.AddHours(-1), 0m);
+        var phase2 = TestHelpers.CreatePhase("2", DateTime.UtcNow, DateTime.UtcNow.AddHours(1), 0m);
+        var phases = (System.Collections.IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(phase1.GetType()))!;
+        phases.Add(phase1);
+        phases.Add(phase2);
+        var projectInfo = TestHelpers.CreateProjectInfo(1, phases);
+
+        var strapi = new Mock<IStrapiClient>();
+        strapi.Setup(x => x.ReceiveProjectInfo("pid", false)).Returns(projectInfo);
+
+        var dynamoDb = new Mock<IDynamoDBContext>();
+        var start1 = (DateTime)((dynamic)phase1).Start;
+        var start2 = (DateTime)((dynamic)phase2).Start;
+        var whiteLists1 = new List<WhiteList>
+        {
+            new("pid", start1, new EthereumAddress("0x0000000000000000000000000000000000000001"), 1),
+        };
+        var whiteLists2 = new List<WhiteList>
+        {
+            new("pid", start2, new EthereumAddress("0x0000000000000000000000000000000000000002"), 2),
+            new("pid", start2, new EthereumAddress("0x0000000000000000000000000000000000000003"), 3),
+        };
+        var hash1 = WhiteList.CalculateHashId("pid", start1);
+        var hash2 = WhiteList.CalculateHashId("pid", start2);
+        dynamoDb.Setup(x => x.QueryAsync<WhiteList>(hash1, null))
+                .Returns(new StubAsyncSearch<WhiteList>(whiteLists1));
+        dynamoDb.Setup(x => x.QueryAsync<WhiteList>(hash2, null))
+                .Returns(new StubAsyncSearch<WhiteList>(whiteLists2));
+
+        var handler = new AdminGetAllocationHandler(strapi.Object, dynamoDb.Object);
+        var request = new AdminGetAllocationRequest("pid");
+
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        Assert.Equal(2, result.Count);
+        var phase1Result = result.First(r => r.PhaseId == "1");
+        Assert.Single(phase1Result.WhiteList);
+        var phase2Result = result.First(r => r.PhaseId == "2");
+        Assert.Equal(2, phase2Result.WhiteList.Count);
+    }
+}

--- a/tests/InvestProvider.Backend.Tests/Handlers/AdminWriteAllocationValidatorTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Handlers/AdminWriteAllocationValidatorTests.cs
@@ -8,7 +8,6 @@ using Moq;
 using Xunit;
 using InvestProvider.Backend.Services.DynamoDb.Models;
 using InvestProvider.Backend.Services.Strapi;
-using InvestProvider.Backend.Services.Strapi.Models;
 using InvestProvider.Backend.Services.Handlers.AdminWriteAllocation;
 using InvestProvider.Backend.Services.Handlers.AdminWriteAllocation.Models;
 using Net.Web3.EthereumWallet;
@@ -18,50 +17,14 @@ namespace InvestProvider.Backend.Tests.Handlers;
 
 public class AdminWriteAllocationValidatorTests
 {
-    private static object CreatePhase(string id, DateTime start, DateTime finish, decimal maxInvest)
-    {
-        var type = Type.GetType("Poolz.Finance.CSharp.Strapi.ComponentPhaseStartEndAmount, Poolz.Finance.CSharp.Strapi")!;
-        var obj = Activator.CreateInstance(type)!;
-        type.GetProperty("Id")?.SetValue(obj, id);
-        type.GetProperty("Start")?.SetValue(obj, (DateTime?)start);
-        type.GetProperty("Finish")?.SetValue(obj, (DateTime?)finish);
-        var maxInvestProp = type.GetProperty("MaxInvest");
-        if (maxInvestProp != null)
-        {
-            var targetType = Nullable.GetUnderlyingType(maxInvestProp.PropertyType) ?? maxInvestProp.PropertyType;
-            object? converted = Convert.ChangeType(maxInvest, targetType);
-            maxInvestProp.SetValue(obj, converted);
-        }
-        return obj;
-    }
-
-    private static ProjectInfo CreateProjectInfo(long chainId, IList phases)
-    {
-        var projectsInfoType = Type.GetType("Poolz.Finance.CSharp.Strapi.ProjectsInformation, Poolz.Finance.CSharp.Strapi")!;
-        var chainSettingType = Type.GetType("Poolz.Finance.CSharp.Strapi.ChainSetting, Poolz.Finance.CSharp.Strapi")!;
-        var chainType = Type.GetType("Poolz.Finance.CSharp.Strapi.Chain, Poolz.Finance.CSharp.Strapi")!;
-
-        var chain = Activator.CreateInstance(chainType)!;
-        chainType.GetProperty("ChainId")?.SetValue(chain, (long?)chainId);
-
-        var chainSetting = Activator.CreateInstance(chainSettingType)!;
-        chainSettingType.GetProperty("Chain")?.SetValue(chainSetting, chain);
-
-        var projectsInfo = Activator.CreateInstance(projectsInfoType)!;
-        projectsInfoType.GetProperty("ChainSetting")?.SetValue(projectsInfo, chainSetting);
-        projectsInfoType.GetProperty("ProjectPhases")?.SetValue(projectsInfo, phases);
-
-        var projectInfoResponse = new ProjectInfoResponse((dynamic)projectsInfo);
-        return new ProjectInfo(projectInfoResponse);
-    }
 
     [Fact]
     public async Task Validate_Succeeds_ForWhitelistPhase()
     {
-        var phase = CreatePhase("1", DateTime.UtcNow, DateTime.UtcNow.AddHours(1), 0m);
+        var phase = TestHelpers.CreatePhase("1", DateTime.UtcNow, DateTime.UtcNow.AddHours(1), 0m);
         var phasesList = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(phase.GetType()))!;
         phasesList.Add(phase);
-        var projectInfo = CreateProjectInfo(1, phasesList);
+        var projectInfo = TestHelpers.CreateProjectInfo(1, phasesList);
 
         var strapi = new Mock<IStrapiClient>();
         strapi.Setup(x => x.ReceiveProjectInfo("pid", false)).Returns(projectInfo);
@@ -81,7 +44,7 @@ public class AdminWriteAllocationValidatorTests
     {
         var type = Type.GetType("Poolz.Finance.CSharp.Strapi.ComponentPhaseStartEndAmount, Poolz.Finance.CSharp.Strapi")!;
         var emptyList = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(type))!;
-        var projectInfo = CreateProjectInfo(1, emptyList);
+        var projectInfo = TestHelpers.CreateProjectInfo(1, emptyList);
 
         var strapi = new Mock<IStrapiClient>();
         strapi.Setup(x => x.ReceiveProjectInfo("pid", false)).Returns(projectInfo);

--- a/tests/InvestProvider.Backend.Tests/StubAsyncSearch.cs
+++ b/tests/InvestProvider.Backend.Tests/StubAsyncSearch.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.DynamoDBv2.DataModel;
+
+namespace InvestProvider.Backend.Tests;
+
+public class StubAsyncSearch<T> : AsyncSearch<T>
+{
+    private readonly List<T> _results;
+
+    public StubAsyncSearch(IEnumerable<T> results)
+    {
+        _results = new List<T>(results);
+    }
+
+    public override Task<List<T>> GetNextSetAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_results);
+    }
+
+    public override Task<List<T>> GetRemainingAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_results);
+    }
+}

--- a/tests/InvestProvider.Backend.Tests/TestHelpers.cs
+++ b/tests/InvestProvider.Backend.Tests/TestHelpers.cs
@@ -46,4 +46,24 @@ public static class TestHelpers
         var projectInfoResponse = new ProjectInfoResponse((dynamic)projectsInfo);
         return new ProjectInfo(projectInfoResponse);
     }
+
+    public static ProjectInfo CreateProjectInfo(long chainId, IList phases)
+    {
+        var projectsInfoType = Type.GetType("Poolz.Finance.CSharp.Strapi.ProjectsInformation, Poolz.Finance.CSharp.Strapi")!;
+        var chainSettingType = Type.GetType("Poolz.Finance.CSharp.Strapi.ChainSetting, Poolz.Finance.CSharp.Strapi")!;
+        var chainType = Type.GetType("Poolz.Finance.CSharp.Strapi.Chain, Poolz.Finance.CSharp.Strapi")!;
+
+        var chain = Activator.CreateInstance(chainType)!;
+        chainType.GetProperty("ChainId")?.SetValue(chain, (long?)chainId);
+
+        var chainSetting = Activator.CreateInstance(chainSettingType)!;
+        chainSettingType.GetProperty("Chain")?.SetValue(chainSetting, chain);
+
+        var projectsInfo = Activator.CreateInstance(projectsInfoType)!;
+        projectsInfoType.GetProperty("ChainSetting")?.SetValue(projectsInfo, chainSetting);
+        projectsInfoType.GetProperty("ProjectPhases")?.SetValue(projectsInfo, phases);
+
+        var projectInfoResponse = new ProjectInfoResponse((dynamic)projectsInfo);
+        return new ProjectInfo(projectInfoResponse);
+    }
 }


### PR DESCRIPTION
## Summary
- add unit tests for AdminGetAllocationHandler
- remove duplicate helper code by expanding TestHelpers
- use TestHelpers in AdminWriteAllocationValidatorTests
- rename FakeAsyncSearch to StubAsyncSearch

## Testing
- `dotnet test tests/InvestProvider.Backend.Tests/InvestProvider.Backend.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6857e8f9070c8330ae7c5ca1c5c66e89