### PR TITLE
Add basic unit tests

### DIFF
--- a/tests/InvestProvider.Backend.Tests/Handlers/AdminWriteAllocationHandlerTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Handlers/AdminWriteAllocationHandlerTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.DynamoDBv2.DataModel;
+using Moq;
+using Xunit;
+using InvestProvider.Backend.Services.Handlers.AdminWriteAllocation;
+using InvestProvider.Backend.Services.Handlers.AdminWriteAllocation.Models;
+using Net.Web3.EthereumWallet;
+using InvestProvider.Backend.Tests;
+
+namespace InvestProvider.Backend.Tests.Handlers;
+
+public class AdminWriteAllocationHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsZero_WhenNoUsers()
+    {
+        var phase = TestHelpers.CreatePhase("1", DateTime.UtcNow, DateTime.UtcNow.AddHours(1), 0m);
+
+        var dynamo = new Mock<IDynamoDBContext>(MockBehavior.Strict);
+        var handler = new AdminWriteAllocationHandler(dynamo.Object);
+        var request = new AdminWriteAllocationRequest("pid", "1", Array.Empty<UserWithAmount>());
+        request.Phase = (dynamic)phase;
+
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        Assert.Equal(0, result.Saved);
+        dynamo.VerifyNoOtherCalls();
+    }
+}

--- a/tests/InvestProvider.Backend.Tests/Services/ChainProviderTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Services/ChainProviderTests.cs
@@ -1,0 +1,49 @@
+using System;
+using Moq;
+using Xunit;
+using Net.Web3.EthereumWallet;
+using InvestProvider.Backend.Services.Strapi;
+using InvestProvider.Backend.Services.Strapi.Models;
+using InvestProvider.Backend.Services.Web3;
+using InvestProvider.Backend.Services.Web3.Contracts;
+
+namespace InvestProvider.Backend.Tests.Services;
+
+public class ChainProviderTests
+{
+    [Fact]
+    public void RpcUrl_IsFetched_FromStrapi_AndCached()
+    {
+        var info = new OnChainInfo("http://rpc", new EthereumAddress("0x00000000000000000000000000000000000000aa"), new EthereumAddress("0x00000000000000000000000000000000000000bb"));
+        var strapi = new Mock<IStrapiClient>();
+        strapi.Setup(x => x.ReceiveOnChainInfo(1)).Returns(info);
+        var provider = new ChainProvider(strapi.Object);
+
+        Assert.Equal("http://rpc", provider.RpcUrl(1));
+        Assert.Equal("http://rpc", provider.RpcUrl(1));
+        strapi.Verify(x => x.ReceiveOnChainInfo(1), Times.Once);
+    }
+
+    [Fact]
+    public void ContractAddress_ReturnsAddress_ForKnownType()
+    {
+        var info = new OnChainInfo("url", new EthereumAddress("0x00000000000000000000000000000000000000aa"), new EthereumAddress("0x00000000000000000000000000000000000000bb"));
+        var strapi = new Mock<IStrapiClient>();
+        strapi.Setup(x => x.ReceiveOnChainInfo(3)).Returns(info);
+        var provider = new ChainProvider(strapi.Object);
+
+        Assert.Equal("0x00000000000000000000000000000000000000aa", provider.ContractAddress(3, ContractType.InvestedProvider));
+        Assert.Equal("0x00000000000000000000000000000000000000bb", provider.ContractAddress(3, ContractType.LockDealNFT));
+    }
+
+    [Fact]
+    public void ContractAddress_Throws_ForUnsupportedType()
+    {
+        var info = new OnChainInfo("url", new EthereumAddress("0x00000000000000000000000000000000000000aa"), new EthereumAddress("0x00000000000000000000000000000000000000bb"));
+        var strapi = new Mock<IStrapiClient>();
+        strapi.Setup(x => x.ReceiveOnChainInfo(4)).Returns(info);
+        var provider = new ChainProvider(strapi.Object);
+
+        Assert.ThrowsAny<Exception>(() => provider.ContractAddress(4, (ContractType)99));
+    }
+}

--- a/tests/InvestProvider.Backend.Tests/Services/DefaultServiceProviderTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Services/DefaultServiceProviderTests.cs
@@ -1,0 +1,23 @@
+using Xunit;
+using InvestProvider.Backend.Services;
+using InvestProvider.Backend.Services.Web3.Contracts;
+using InvestProvider.Backend.Services.Web3;
+using InvestProvider.Backend.Services.Strapi;
+using NethereumGenerators.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace InvestProvider.Backend.Tests.Services;
+
+public class DefaultServiceProviderTests
+{
+    [Fact]
+    public void Build_ResolvesCoreServices()
+    {
+        Environment.SetEnvironmentVariable("STRAPI_GRAPHQL_URL", "http://localhost");
+        var sp = DefaultServiceProvider.Build();
+        Assert.NotNull(sp.GetRequiredService<IChainProvider<ContractType>>());
+        Assert.NotNull(sp.GetRequiredService<IRpcProvider>());
+        Assert.NotNull(sp.GetRequiredService<IStrapiClient>());
+    }
+}

--- a/tests/InvestProvider.Backend.Tests/Services/InvestProviderLambdaTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Services/InvestProviderLambdaTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation;
+using MediatR;
+using Moq;
+using Xunit;
+using InvestProvider.Backend.Models;
+using InvestProvider.Backend;
+using Microsoft.Extensions.DependencyInjection;
+using InvestProvider.Backend.Services.Handlers.MyAllocation.Models;
+
+namespace InvestProvider.Backend.Tests.Services;
+
+public class InvestProviderLambdaTests
+{
+    [Fact]
+    public async Task RunAsync_ReturnsHandlerResponse()
+    {
+        var services = new ServiceCollection();
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(x => x.Send(It.IsAny<object>(), It.IsAny<CancellationToken>())).ReturnsAsync("ok");
+        services.AddSingleton(mediator.Object);
+        var lambda = new InvestProviderLambda(services.BuildServiceProvider());
+
+        var req = new LambdaRequest { MyAllocation = new InvestProvider.Backend.Services.Handlers.MyAllocation.Models.MyAllocationRequest("p", new Net.Web3.EthereumWallet.EthereumAddress("0x0000000000000000000000000000000000000001")) };
+        var response = await lambda.RunAsync(req);
+
+        Assert.Equal("ok", response.HandlerResponse);
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsError_OnValidationException()
+    {
+        var services = new ServiceCollection();
+        var mediator = new Mock<IMediator>();
+        var failures = new[] { new FluentValidation.Results.ValidationFailure("field", "err") { ErrorCode = "code" } };
+        mediator.Setup(x => x.Send(It.IsAny<object>(), It.IsAny<CancellationToken>())).ThrowsAsync(new ValidationException(failures));
+        services.AddSingleton(mediator.Object);
+        var lambda = new InvestProviderLambda(services.BuildServiceProvider());
+
+        var req = new LambdaRequest { MyAllocation = new InvestProvider.Backend.Services.Handlers.MyAllocation.Models.MyAllocationRequest("p", new Net.Web3.EthereumWallet.EthereumAddress("0x0000000000000000000000000000000000000001")) };
+        var response = await lambda.RunAsync(req);
+
+        Assert.Equal("err", response.ErrorMessage);
+        Assert.Equal("code", response.ErrorType);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for AdminWriteAllocationHandler handler
- test ChainProvider addresses and caching
- test default service provider registration
- add lambda entrypoint tests

## Testing
- `dotnet test tests/InvestProvider.Backend.Tests/InvestProvider.Backend.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6857f21450e88330a9e2e1297abc86d5