### PR TITLE
Add EnvSignerManager unit tests

### DIFF
--- a/tests/InvestProvider.Backend.Tests/Services/EnvSignerManagerTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Services/EnvSignerManagerTests.cs
@@ -1,0 +1,20 @@
+using System;
+using Xunit;
+using InvestProvider.Backend.Services.Web3;
+
+namespace InvestProvider.Backend.Tests.Services;
+
+public class EnvSignerManagerTests
+{
+    [Fact]
+    public void GetSigner_ReturnsKey_FromEnvironment()
+    {
+        var key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        Environment.SetEnvironmentVariable("PRIVATE_KEY_OF_LOCAL_SIGN_ACCOUNT", key);
+
+        var manager = new EnvSignerManager();
+        var signer = manager.GetSigner();
+
+        Assert.Equal("0x" + key, signer.GetPrivateKey());
+    }
+}


### PR DESCRIPTION
## Summary
- add test for EnvSignerManager to ensure signer is created from environment variable

## Testing
- `dotnet test tests/InvestProvider.Backend.Tests/InvestProvider.Backend.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6858128638088330ad6cbceb7fb45d51