### PR TITLE
Refactor DynamoDb batch loading to be testable

### DIFF
--- a/src/InvestProvider.Backend/Extensions/DynamoDbExtensions.cs
+++ b/src/InvestProvider.Backend/Extensions/DynamoDbExtensions.cs
@@ -1,14 +1,15 @@
 ﻿using Amazon.DynamoDBv2.DataModel;
+using System.Linq;
 
 namespace InvestProvider.Backend.Extensions;
 
 public static class DynamoDbExtensions
 {
     public static async Task<List<T>> BatchLoadAsync<T>(this IDynamoDBContext dynamoDb, IEnumerable<object> keys, CancellationToken ct = default)
+        where T : class
     {
-        var batch = dynamoDb.CreateBatchGet<T>();
-        foreach (var k in keys) batch.AddKey(k);
-        await batch.ExecuteAsync(ct);
-        return batch.Results;
+        var tasks = keys.Select(k => dynamoDb.LoadAsync<T>(k, ct));
+        var results = await Task.WhenAll(tasks);
+        return results.Where(r => r != null).ToList()!;
     }
 }

--- a/tests/InvestProvider.Backend.Tests/Extensions/DynamoDbExtensionsTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Extensions/DynamoDbExtensionsTests.cs
@@ -1,0 +1,33 @@
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Amazon.DynamoDBv2.DataModel;
+using Moq;
+using Xunit;
+using InvestProvider.Backend.Extensions;
+using InvestProvider.Backend.Services.DynamoDb.Models;
+
+namespace InvestProvider.Backend.Tests.Extensions;
+
+public class DynamoDbExtensionsTests
+{
+    [Fact]
+    public async Task BatchLoadAsync_LoadsEachKeyAndReturnsResults()
+    {
+        var dynamoDb = new Mock<IDynamoDBContext>();
+        var keys = new[] { "k1", "k2" };
+        var item1 = new ProjectsInformation { ProjectId = "k1", PoolzBackId = 1 };
+        var item2 = new ProjectsInformation { ProjectId = "k2", PoolzBackId = 2 };
+
+        dynamoDb.Setup(x => x.LoadAsync<ProjectsInformation>("k1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item1);
+        dynamoDb.Setup(x => x.LoadAsync<ProjectsInformation>("k2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(item2);
+
+        var result = await dynamoDb.Object.BatchLoadAsync<ProjectsInformation>(keys, CancellationToken.None);
+
+        Assert.Equal(new[] { item1, item2 }, result);
+        dynamoDb.Verify(x => x.LoadAsync<ProjectsInformation>("k1", It.IsAny<CancellationToken>()), Times.Once);
+        dynamoDb.Verify(x => x.LoadAsync<ProjectsInformation>("k2", It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- change BatchLoadAsync to use LoadAsync for each key
- add a unit test covering the BatchLoadAsync extension

## Testing
- `dotnet test tests/InvestProvider.Backend.Tests/InvestProvider.Backend.Tests.csproj --logger "console;verbosity=detailed"`

------
https://chatgpt.com/codex/tasks/task_e_6858126c6adc8330b511c40339e476b4