### PR TITLE
Add SignerManager unit test

### DIFF
--- a/tests/InvestProvider.Backend.Tests/Services/SignerManagerTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Services/SignerManagerTests.cs
@@ -1,0 +1,29 @@
+using System;
+using Moq;
+using SecretsManager;
+using Xunit;
+using InvestProvider.Backend.Services.Web3;
+
+namespace InvestProvider.Backend.Tests.Services;
+
+public class SignerManagerTests
+{
+    [Fact]
+    public void GetSigner_ReturnsKey_FromSecretsManager()
+    {
+        var secretId = "sid";
+        var secretKey = "skey";
+        var privateKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        Environment.SetEnvironmentVariable("SECRET_ID_OF_SIGN_ACCOUNT", secretId);
+        Environment.SetEnvironmentVariable("SECRET_KEY_OF_SIGN_ACCOUNT", secretKey);
+
+        var secrets = new Mock<SecretManager>();
+        secrets.Setup(x => x.GetSecretValue(secretId, secretKey)).Returns(privateKey);
+
+        var manager = new SignerManager(secrets.Object);
+        var signer = manager.GetSigner();
+
+        Assert.Equal("0x" + privateKey, signer.GetPrivateKey());
+        secrets.Verify(x => x.GetSecretValue(secretId, secretKey), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- test SignerManager to ensure signer key loaded from AWS Secrets Manager

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685820dc20988330b42c4af5854744e0