### PR TITLE
Refactor Strapi client queries

### DIFF
--- a/src/InvestProvider.Backend/Services/Handlers/AdminGetAllocation/AdminGetAllocationHandler.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/AdminGetAllocation/AdminGetAllocationHandler.cs
@@ -16,7 +16,7 @@ public class AdminGetAllocationHandler(IStrapiClient strapi, IDynamoDBContext dy
 
     public async Task<ICollection<AdminGetAllocationResponse>> Handle(AdminGetAllocationRequest request, CancellationToken cancellationToken)
     {
-        var projectInfo = strapi.ReceiveProjectInfo(request.ProjectId, filterPhases: false);
+        var projectInfo = await strapi.ReceiveProjectInfoAsync(request.ProjectId, filterPhases: false);
 
         var throttler = new SemaphoreSlim(MaxParallel);
         var whiteListPhases = projectInfo.Phases.Where(x => x.MaxInvest == 0);

--- a/src/InvestProvider.Backend/Services/Handlers/BasePhaseValidator.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/BasePhaseValidator.cs
@@ -15,7 +15,9 @@ public abstract class BasePhaseValidator<T>(IStrapiClient strapi, IDynamoDBConte
 
     protected bool NotNullCurrentPhase(IExistActivePhase model)
     {
-        model.StrapiProjectInfo = _strapi.ReceiveProjectInfo(model.ProjectId, filterPhases: model.FilterPhases);
+        model.StrapiProjectInfo = _strapi.ReceiveProjectInfoAsync(model.ProjectId, filterPhases: model.FilterPhases)
+            .GetAwaiter()
+            .GetResult();
         return model.StrapiProjectInfo.CurrentPhase != null;
     }
 

--- a/src/InvestProvider.Backend/Services/Strapi/IStrapiClient.cs
+++ b/src/InvestProvider.Backend/Services/Strapi/IStrapiClient.cs
@@ -1,9 +1,10 @@
-﻿using InvestProvider.Backend.Services.Strapi.Models;
+﻿using System.Threading.Tasks;
+using InvestProvider.Backend.Services.Strapi.Models;
 
 namespace InvestProvider.Backend.Services.Strapi;
 
 public interface IStrapiClient
 {
-    public OnChainInfo ReceiveOnChainInfo(long chainId);
-    public ProjectInfo ReceiveProjectInfo(string projectId, bool filterPhases);
+    Task<OnChainInfo> ReceiveOnChainInfoAsync(long chainId);
+    Task<ProjectInfo> ReceiveProjectInfoAsync(string projectId, bool filterPhases);
 }

--- a/src/InvestProvider.Backend/Services/Strapi/StrapiClient.cs
+++ b/src/InvestProvider.Backend/Services/Strapi/StrapiClient.cs
@@ -1,6 +1,7 @@
 ﻿using GraphQL;
 using GraphQL.Client.Http;
 using System.Net.Http.Headers;
+using System.Threading.Tasks;
 using Net.Web3.EthereumWallet;
 using Poolz.Finance.CSharp.Strapi;
 using EnvironmentManager.Extensions;
@@ -33,11 +34,9 @@ public class StrapiClient : IStrapiClient
         }
     );
 
-    public OnChainInfo ReceiveOnChainInfo(long chainId)
+    public async Task<OnChainInfo> ReceiveOnChainInfoAsync(long chainId)
     {
-        var response = SendQueryAsync<OnChainInfoResponse>(OnChainInfoRequest.BuildRequest(chainId))
-            .GetAwaiter()
-            .GetResult();
+        var response = await SendQueryAsync<OnChainInfoResponse>(OnChainInfoRequest.BuildRequest(chainId));
 
         if (response.Data.Chains.Count == 0 || response.Data.Chains.First().ContractsOnChain == null)
         {
@@ -54,11 +53,9 @@ public class StrapiClient : IStrapiClient
         return new OnChainInfo(chain.ContractsOnChain.Rpc, investedProvider, lockDealNFT);
     }
 
-    public ProjectInfo ReceiveProjectInfo(string projectId, bool filterPhases)
+    public async Task<ProjectInfo> ReceiveProjectInfoAsync(string projectId, bool filterPhases)
     {
-        var response = SendQueryAsync<ProjectInfoResponse>(ProjectPhaseRequest.BuildRequest(projectId, filterPhases))
-            .GetAwaiter()
-            .GetResult();
+        var response = await SendQueryAsync<ProjectInfoResponse>(ProjectPhaseRequest.BuildRequest(projectId, filterPhases));
 
         if (response.Data.ProjectsInfo == null)
         {

--- a/src/InvestProvider.Backend/Services/Web3/ChainProvider.cs
+++ b/src/InvestProvider.Backend/Services/Web3/ChainProvider.cs
@@ -39,7 +39,7 @@ public class ChainProvider(IStrapiClient strapi) : IChainProvider<ContractType>,
             .GetOrAdd(
                 chainId,
                 x => new Lazy<OnChainInfo>(
-                    () => strapi.ReceiveOnChainInfo(x),
+                    () => strapi.ReceiveOnChainInfoAsync(x).GetAwaiter().GetResult(),
                     LazyThreadSafetyMode.ExecutionAndPublication
                 )
             ).Value;

--- a/tests/InvestProvider.Backend.Tests/Handlers/AdminCreatePoolzBackIdValidatorTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Handlers/AdminCreatePoolzBackIdValidatorTests.cs
@@ -26,7 +26,7 @@ public class AdminCreatePoolzBackIdValidatorTests
         var projectInfo = TestHelpers.CreateProjectInfo(1, phase);
 
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveProjectInfo("pid", false)).Returns(projectInfo);
+        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", false)).ReturnsAsync(projectInfo);
 
         var lockDealNFT = new Mock<ILockDealNFTService<ContractType>>();
         var poolInfo = new List<BasePoolInfo>
@@ -57,7 +57,7 @@ public class AdminCreatePoolzBackIdValidatorTests
         var projectInfo = TestHelpers.CreateProjectInfo(1, phase);
 
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveProjectInfo("pid", false)).Returns(projectInfo);
+        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", false)).ReturnsAsync(projectInfo);
 
         var lockDealNFT = new Mock<ILockDealNFTService<ContractType>>();
         var poolInfo = new List<BasePoolInfo>

--- a/tests/InvestProvider.Backend.Tests/Handlers/AdminGetAllocationHandlerTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Handlers/AdminGetAllocationHandlerTests.cs
@@ -28,7 +28,7 @@ public class AdminGetAllocationHandlerTests
         var projectInfo = TestHelpers.CreateProjectInfo(1, phases);
 
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveProjectInfo("pid", false)).Returns(projectInfo);
+        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", false)).ReturnsAsync(projectInfo);
 
         var dynamoDb = new Mock<IDynamoDBContext>();
         var start1 = (DateTime)((dynamic)phase1).Start;
@@ -70,7 +70,7 @@ public class AdminGetAllocationHandlerTests
         var projectInfo = TestHelpers.CreateProjectInfo(1, phases);
 
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveProjectInfo("pid", false)).Returns(projectInfo);
+        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", false)).ReturnsAsync(projectInfo);
 
         var dynamoDb = new Mock<IDynamoDBContext>();
         var start = (DateTime)((dynamic)phase).Start;

--- a/tests/InvestProvider.Backend.Tests/Handlers/AdminWriteAllocationValidatorTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Handlers/AdminWriteAllocationValidatorTests.cs
@@ -27,7 +27,7 @@ public class AdminWriteAllocationValidatorTests
         var projectInfo = TestHelpers.CreateProjectInfo(1, phasesList);
 
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveProjectInfo("pid", false)).Returns(projectInfo);
+        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", false)).ReturnsAsync(projectInfo);
 
         var dynamoDb = new Mock<IDynamoDBContext>();
         dynamoDb.Setup(x => x.LoadAsync<ProjectsInformation>("pid", It.IsAny<CancellationToken>()))
@@ -47,7 +47,7 @@ public class AdminWriteAllocationValidatorTests
         var projectInfo = TestHelpers.CreateProjectInfo(1, emptyList);
 
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveProjectInfo("pid", false)).Returns(projectInfo);
+        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", false)).ReturnsAsync(projectInfo);
 
         var dynamoDb = new Mock<IDynamoDBContext>();
         dynamoDb.Setup(x => x.LoadAsync<ProjectsInformation>("pid", It.IsAny<CancellationToken>()))

--- a/tests/InvestProvider.Backend.Tests/Handlers/GenerateSignatureValidatorTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Handlers/GenerateSignatureValidatorTests.cs
@@ -62,7 +62,7 @@ public class GenerateSignatureValidatorTests
         var projectInfo = TestHelpers.CreateProjectInfo(1, phase);
 
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveProjectInfo("pid", It.IsAny<bool>())).Returns(projectInfo);
+        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", It.IsAny<bool>())).ReturnsAsync(projectInfo);
 
         var dynamoDb = new Mock<IDynamoDBContext>();
         Environment.SetEnvironmentVariable("AWS_REGION", "us-east-1");
@@ -91,7 +91,7 @@ public class GenerateSignatureValidatorTests
         var projectInfo = TestHelpers.CreateProjectInfo(1, phase);
 
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveProjectInfo("pid", It.IsAny<bool>())).Returns(projectInfo);
+        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", It.IsAny<bool>())).ReturnsAsync(projectInfo);
 
         var dynamoDb = new Mock<IDynamoDBContext>();
         var start = (DateTime)((dynamic)phase).Start;

--- a/tests/InvestProvider.Backend.Tests/Handlers/MyAllocationHandlerTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Handlers/MyAllocationHandlerTests.cs
@@ -25,7 +25,7 @@ public class MyAllocationHandlerTests
         var projectInfo = TestHelpers.CreateProjectInfo(1, phase);
 
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveProjectInfo("pid", false)).Returns(projectInfo);
+        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", false)).ReturnsAsync(projectInfo);
 
         var dynamoDb = new Mock<IDynamoDBContext>();
         var projectData = new ProjectsInformation { ProjectId = "pid", PoolzBackId = 5 };
@@ -58,7 +58,7 @@ public class MyAllocationHandlerTests
         var projectInfo = TestHelpers.CreateProjectInfo(1, phase);
 
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveProjectInfo("pid", false)).Returns(projectInfo);
+        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", false)).ReturnsAsync(projectInfo);
 
         var dynamoDb = new Mock<IDynamoDBContext>();
         var projectData = new ProjectsInformation { ProjectId = "pid", PoolzBackId = 5 };

--- a/tests/InvestProvider.Backend.Tests/Services/ChainProviderTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Services/ChainProviderTests.cs
@@ -16,12 +16,12 @@ public class ChainProviderTests
     {
         var info = new OnChainInfo("http://rpc", new EthereumAddress("0x00000000000000000000000000000000000000aa"), new EthereumAddress("0x00000000000000000000000000000000000000bb"));
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveOnChainInfo(1)).Returns(info);
+        strapi.Setup(x => x.ReceiveOnChainInfoAsync(1)).ReturnsAsync(info);
         var provider = new ChainProvider(strapi.Object);
 
         Assert.Equal("http://rpc", provider.RpcUrl(1));
         Assert.Equal("http://rpc", provider.RpcUrl(1));
-        strapi.Verify(x => x.ReceiveOnChainInfo(1), Times.Once);
+        strapi.Verify(x => x.ReceiveOnChainInfoAsync(1), Times.Once);
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public class ChainProviderTests
     {
         var info = new OnChainInfo("url", new EthereumAddress("0x00000000000000000000000000000000000000aa"), new EthereumAddress("0x00000000000000000000000000000000000000bb"));
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveOnChainInfo(3)).Returns(info);
+        strapi.Setup(x => x.ReceiveOnChainInfoAsync(3)).ReturnsAsync(info);
         var provider = new ChainProvider(strapi.Object);
 
         Assert.Equal("0x00000000000000000000000000000000000000aa", provider.ContractAddress(3, ContractType.InvestedProvider));
@@ -41,7 +41,7 @@ public class ChainProviderTests
     {
         var info = new OnChainInfo("url", new EthereumAddress("0x00000000000000000000000000000000000000aa"), new EthereumAddress("0x00000000000000000000000000000000000000bb"));
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveOnChainInfo(4)).Returns(info);
+        strapi.Setup(x => x.ReceiveOnChainInfoAsync(4)).ReturnsAsync(info);
         var provider = new ChainProvider(strapi.Object);
 
         Assert.ThrowsAny<Exception>(() => provider.ContractAddress(4, (ContractType)99));

--- a/tests/InvestProvider.Backend.Tests/Services/StrapiClientQueryTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Services/StrapiClientQueryTests.cs
@@ -48,7 +48,7 @@ public class StrapiClientQueryTests
     }
 
     [Fact]
-    public void ReceiveOnChainInfo_ReturnsInfo()
+    public async Task ReceiveOnChainInfoAsync_ReturnsInfo()
     {
         Environment.SetEnvironmentVariable("STRAPI_GRAPHQL_URL", "http://localhost");
 
@@ -80,7 +80,7 @@ public class StrapiClientQueryTests
         var client = new StrapiClient();
         SetClient(client, stub);
 
-        var result = client.ReceiveOnChainInfo(5);
+        var result = await client.ReceiveOnChainInfoAsync(5);
 
         Assert.Equal("http://rpc", result.RpcUrl);
         Assert.Equal("0x00000000000000000000000000000000000000aa", result.InvestedProvider.ToString());
@@ -88,7 +88,7 @@ public class StrapiClientQueryTests
     }
 
     [Fact]
-    public void ReceiveOnChainInfo_Throws_WhenChainMissing()
+    public async Task ReceiveOnChainInfoAsync_Throws_WhenChainMissing()
     {
         Environment.SetEnvironmentVariable("STRAPI_GRAPHQL_URL", "http://localhost");
         var gqlResponse = new GraphQLResponse<OnChainInfoResponse> { Data = new OnChainInfoResponse(Array.Empty<Chain>()) };
@@ -97,11 +97,11 @@ public class StrapiClientQueryTests
         var client = new StrapiClient();
         SetClient(client, stub);
 
-        Assert.Throws<ValidationException>(() => client.ReceiveOnChainInfo(7));
+        await Assert.ThrowsAsync<ValidationException>(() => client.ReceiveOnChainInfoAsync(7));
     }
 
     [Fact]
-    public void ReceiveProjectInfo_ReturnsInfo()
+    public async Task ReceiveProjectInfoAsync_ReturnsInfo()
     {
         Environment.SetEnvironmentVariable("STRAPI_GRAPHQL_URL", "http://localhost");
 
@@ -131,13 +131,13 @@ public class StrapiClientQueryTests
         var client = new StrapiClient();
         SetClient(client, stub);
 
-        var info = client.ReceiveProjectInfo("pid", false);
+        var info = await client.ReceiveProjectInfoAsync("pid", false);
         Assert.Equal(3, info.ChainId);
         Assert.Single(info.Phases);
     }
 
     [Fact]
-    public void ReceiveProjectInfo_Throws_WhenProjectMissing()
+    public async Task ReceiveProjectInfoAsync_Throws_WhenProjectMissing()
     {
         Environment.SetEnvironmentVariable("STRAPI_GRAPHQL_URL", "http://localhost");
         var gqlResponse = new GraphQLResponse<ProjectInfoResponse> { Data = new ProjectInfoResponse(null!) };
@@ -146,7 +146,7 @@ public class StrapiClientQueryTests
         var client = new StrapiClient();
         SetClient(client, stub);
 
-        Assert.Throws<ValidationException>(() => client.ReceiveProjectInfo("pid", true));
+        await Assert.ThrowsAsync<ValidationException>(() => client.ReceiveProjectInfoAsync("pid", true));
     }
 
     [Fact]

--- a/tests/InvestProvider.Backend.Tests/Services/StrapiClientQueryTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Services/StrapiClientQueryTests.cs
@@ -164,14 +164,15 @@ public class StrapiClientQueryTests
         var client = new StrapiClient();
         SetClient(client, stub);
 
-        var method = typeof(StrapiClient).GetMethod("SendQuery", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var method = typeof(StrapiClient).GetMethod("SendQueryAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
         var generic = method.MakeGenericMethod(typeof(OnChainInfoResponse));
 
         void Act()
         {
             try
             {
-                generic.Invoke(client, new object[] { new GraphQLRequest(), (Action<GraphQLResponse<OnChainInfoResponse>>)(_ => { }) });
+                var task = (Task)generic.Invoke(client, new object[] { new GraphQLRequest() })!;
+                task.GetAwaiter().GetResult();
             }
             catch (TargetInvocationException ex)
             {


### PR DESCRIPTION
## Summary
- adjust StrapiClient to call GraphQL first then validate
- remove lambda validation from SendQuery and rename to SendQueryAsync
- update tests for new private method signature

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6858297f5fd08330a036999716d9ad97