### PR TITLE
Fix SonarCloud scanner install

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -44,7 +44,6 @@ jobs:
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
       - name: Install SonarCloud scanner
-        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         run: |
           mkdir -p ./.sonar/scanner
           dotnet tool update dotnet-sonarscanner --tool-path ./.sonar/scanner


### PR DESCRIPTION
## Summary
- always update `dotnet-sonarscanner` in CI workflow to avoid using an outdated cached version

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68591f6f260c8330b3b7111dcc4e5437