### PR TITLE
Fix MyAllocationHandler tests

### DIFF
--- a/tests/InvestProvider.Backend.Tests/Handlers/MyAllocationHandlerTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Handlers/MyAllocationHandlerTests.cs
@@ -25,7 +25,7 @@ public class MyAllocationHandlerTests
         var projectInfo = TestHelpers.CreateProjectInfo(1, phase);
 
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", false)).ReturnsAsync(projectInfo);
+        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", true)).ReturnsAsync(projectInfo);
 
         var dynamoDb = new Mock<IDynamoDBContext>();
         var projectData = new ProjectsInformation { ProjectId = "pid", PoolzBackId = 5 };
@@ -58,7 +58,7 @@ public class MyAllocationHandlerTests
         var projectInfo = TestHelpers.CreateProjectInfo(1, phase);
 
         var strapi = new Mock<IStrapiClient>();
-        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", false)).ReturnsAsync(projectInfo);
+        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", true)).ReturnsAsync(projectInfo);
 
         var dynamoDb = new Mock<IDynamoDBContext>();
         var projectData = new ProjectsInformation { ProjectId = "pid", PoolzBackId = 5 };


### PR DESCRIPTION
## Summary
- update tests to use the expected `filterPhases` value when mocking Strapi

## Testing
- `dotnet test InvestProvider.Backend.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68593cdabbf88330bab91cb9b9ed0346