### PR TITLE
Return allocation for FCFS phases

### DIFF
--- a/src/InvestProvider.Backend/Services/Handlers/BasePhaseValidator.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/BasePhaseValidator.cs
@@ -46,7 +46,7 @@ public abstract class BasePhaseValidator<T>(IStrapiClient strapi, IDynamoDBConte
         return model.WhiteList != null;
     }
 
-    protected static IRuleBuilderOptions<TModel, TModel> WhiteListPhaseRules<TModel>(BasePhaseValidator<TModel> validator)
+    protected static IRuleBuilderOptions<TModel, TModel> ActivePhaseRules<TModel>(BasePhaseValidator<TModel> validator)
         where TModel : IExistPhase, IValidatedDynamoDbProjectInfo
     {
         return validator.RuleFor(x => x)
@@ -58,7 +58,13 @@ public abstract class BasePhaseValidator<T>(IStrapiClient strapi, IDynamoDBConte
             .Must(m => SetPhase(m))
             .WithError(Error.PHASE_IN_PROJECT_NOT_FOUND, x => new { x.ProjectId, x.PhaseId })
             .Must(x => DateTime.UtcNow < x.Phase.Finish)
-            .WithError(Error.PHASE_FINISHED, x => new { EndTime = x.Phase.Finish, NowTime = DateTime.UtcNow })
+            .WithError(Error.PHASE_FINISHED, x => new { EndTime = x.Phase.Finish, NowTime = DateTime.UtcNow });
+    }
+
+    protected static IRuleBuilderOptions<TModel, TModel> WhiteListPhaseRules<TModel>(BasePhaseValidator<TModel> validator)
+        where TModel : IExistPhase, IValidatedDynamoDbProjectInfo
+    {
+        return ActivePhaseRules(validator)
             .Must(x => x.Phase.MaxInvest == 0)
             .WithError(Error.PHASE_IS_NOT_WHITELIST);
     }

--- a/src/InvestProvider.Backend/Services/Handlers/MyAllocation/Models/MyAllocationRequest.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/MyAllocation/Models/MyAllocationRequest.cs
@@ -42,5 +42,8 @@ public class MyAllocationRequest(string projectId, EthereumAddress userAddress) 
     public WhiteList WhiteList { get; set; } = null!;
 
     [JsonIgnore]
+    public bool UsedCurrentPhase { get; set; }
+
+    [JsonIgnore]
     public long ChainId => StrapiProjectInfo.ChainId;
 }

--- a/src/InvestProvider.Backend/Services/Handlers/MyAllocation/MyAllocationHandler.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/MyAllocation/MyAllocationHandler.cs
@@ -1,15 +1,31 @@
 ﻿using MediatR;
 using InvestProvider.Backend.Services.Handlers.MyAllocation.Models;
+using System;
 
 namespace InvestProvider.Backend.Services.Handlers.MyAllocation;
 
 public class MyAllocationHandler
     : IRequestHandler<MyAllocationRequest, MyAllocationResponse>
 {
-    public Task<MyAllocationResponse> Handle(MyAllocationRequest request, CancellationToken cancellationToken) => Task.FromResult(new MyAllocationResponse(
-            amount: request.WhiteList.Amount,
-            startTime: request.StrapiProjectInfo.CurrentPhase!.Start!.Value,
-            endTime: request.StrapiProjectInfo.CurrentPhase.Finish!.Value,
-            poolzBackId: request.DynamoDbProjectsInfo.PoolzBackId
+    public Task<MyAllocationResponse> Handle(MyAllocationRequest request, CancellationToken cancellationToken)
+    {
+        var phase = request.StrapiProjectInfo.CurrentPhase!;
+        decimal amount;
+        var maxInvest = Convert.ToDecimal(phase.MaxInvest ?? 0);
+        if (maxInvest == 0)
+        {
+            amount = request.WhiteList.Amount;
+        }
+        else
+        {
+            amount = request.UsedCurrentPhase ? 0m : maxInvest;
+        }
+
+        return Task.FromResult(new MyAllocationResponse(
+            amount,
+            phase.Start!.Value,
+            phase.Finish!.Value,
+            request.DynamoDbProjectsInfo.PoolzBackId
         ));
+    }
 }

--- a/src/InvestProvider.Backend/Services/Handlers/MyAllocation/MyAllocationValidator.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/MyAllocation/MyAllocationValidator.cs
@@ -1,20 +1,51 @@
 using FluentValidation;
 using Net.Utils.ErrorHandler.Extensions;
+using System.Linq;
 using Amazon.DynamoDBv2.DataModel;
 using InvestProvider.Backend.Services.Strapi;
 using InvestProvider.Backend.Services.Handlers.MyAllocation.Models;
+using InvestProvider.Backend.Services.Web3.Contracts;
+using InvestProvider.Backend.Services.Web3;
+using poolz.finance.csharp.contracts.InvestProvider;
+using poolz.finance.csharp.contracts.InvestProvider.ContractDefinition;
 
 namespace InvestProvider.Backend.Services.Handlers.MyAllocation;
 
 public class MyAllocationValidator : BasePhaseValidator<MyAllocationRequest>
 {
-    public MyAllocationValidator(IStrapiClient strapi, IDynamoDBContext dynamoDb)
+    private readonly IInvestProviderService<ContractType> _investProvider;
+
+    public MyAllocationValidator(IStrapiClient strapi, IDynamoDBContext dynamoDb, IInvestProviderService<ContractType> investProvider)
         : base(strapi, dynamoDb)
     {
+        _investProvider = investProvider;
+
         ClassLevelCascadeMode = CascadeMode.Stop;
 
-        WhiteListPhaseRules(this)
+        ActivePhaseRules(this)
+            .CustomAsync(SetAdditionalDataAsync);
+
+        RuleFor(x => x)
             .MustAsync(NotNullWhiteListAsync)
-            .WithError(Error.NOT_IN_WHITE_LIST, x => new { x.ProjectId, PhaseId = x.StrapiProjectInfo.CurrentPhase!.Id, UserAddress = x.UserAddress.Address });
+            .WithError(Error.NOT_IN_WHITE_LIST, x => new { x.ProjectId, PhaseId = x.StrapiProjectInfo.CurrentPhase!.Id, UserAddress = x.UserAddress.Address })
+            .When(x => x.StrapiProjectInfo.CurrentPhase!.MaxInvest == 0);
+    }
+
+    private async Task SetAdditionalDataAsync(MyAllocationRequest model, ValidationContext<MyAllocationRequest> context, CancellationToken token)
+    {
+        if (model.StrapiProjectInfo.CurrentPhase!.MaxInvest != 0)
+        {
+            var response = await _investProvider.GetUserInvestsQueryAsync(
+                model.StrapiProjectInfo.ChainId,
+                ContractType.InvestedProvider,
+                model.DynamoDbProjectsInfo.PoolzBackId,
+                model.UserAddress);
+
+            model.UsedCurrentPhase = response.ReturnValue1.Any(ui =>
+            {
+                var dt = DateTimeOffset.FromUnixTimeSeconds((long)ui.BlockTimestamp).UtcDateTime;
+                return dt >= model.StrapiProjectInfo.CurrentPhase!.Start && dt < model.StrapiProjectInfo.CurrentPhase.Finish;
+            });
+        }
     }
 }

--- a/tests/InvestProvider.Backend.Tests/Handlers/MyAllocationHandlerTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Handlers/MyAllocationHandlerTests.cs
@@ -12,6 +12,10 @@ using InvestProvider.Backend.Services.Handlers.MyAllocation.Models;
 using Net.Web3.EthereumWallet;
 using FluentValidation;
 using InvestProvider.Backend.Tests;
+using InvestProvider.Backend.Services.Web3.Contracts;
+using InvestProvider.Backend.Services.Web3;
+using poolz.finance.csharp.contracts.InvestProvider.ContractDefinition;
+using poolz.finance.csharp.contracts.InvestProvider;
 
 namespace InvestProvider.Backend.Tests.Handlers;
 
@@ -38,7 +42,15 @@ public class MyAllocationHandlerTests
         dynamoDb.Setup(x => x.LoadAsync<WhiteList>(WhiteList.CalculateHashId("pid", startTime), address.Address, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(whiteList);
 
-        var validator = new MyAllocationValidator(strapi.Object, dynamoDb.Object);
+        var investProvider = new Mock<IInvestProviderService<ContractType>>();
+        investProvider.Setup(x => x.GetUserInvestsQueryAsync(
+                It.IsAny<long>(),
+                ContractType.InvestedProvider,
+                It.IsAny<global::System.Numerics.BigInteger>(),
+                It.IsAny<string>(),
+                null))
+            .ReturnsAsync(new poolz.finance.csharp.contracts.InvestProvider.ContractDefinition.GetUserInvestsOutputDTO { ReturnValue1 = [] });
+        var validator = new MyAllocationValidator(strapi.Object, dynamoDb.Object, investProvider.Object);
         var handler = new MyAllocationHandler();
         var request = new MyAllocationRequest("pid", address);
 
@@ -67,7 +79,15 @@ public class MyAllocationHandlerTests
         dynamoDb.Setup(x => x.LoadAsync<WhiteList>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<WhiteList>(null!));
 
-        var validator = new MyAllocationValidator(strapi.Object, dynamoDb.Object);
+        var investProvider = new Mock<IInvestProviderService<ContractType>>();
+        investProvider.Setup(x => x.GetUserInvestsQueryAsync(
+                It.IsAny<long>(),
+                ContractType.InvestedProvider,
+                It.IsAny<global::System.Numerics.BigInteger>(),
+                It.IsAny<string>(),
+                null))
+            .ReturnsAsync(new poolz.finance.csharp.contracts.InvestProvider.ContractDefinition.GetUserInvestsOutputDTO { ReturnValue1 = [] });
+        var validator = new MyAllocationValidator(strapi.Object, dynamoDb.Object, investProvider.Object);
         var handler = new MyAllocationHandler();
         var request = new MyAllocationRequest("pid", new EthereumAddress("0x0000000000000000000000000000000000000123"));
 
@@ -78,4 +98,38 @@ public class MyAllocationHandlerTests
         });
         Assert.Contains("User not in white list", ex.Message);
     }
+
+    [Fact]
+    public async Task Handle_ReturnsMaxInvest_ForFcfsPhase_WhenNotUsed()
+    {
+        var phase = TestHelpers.CreatePhase("3", DateTime.UtcNow, DateTime.UtcNow.AddHours(1), 5m);
+        var projectInfo = TestHelpers.CreateProjectInfo(1, phase);
+
+        var strapi = new Mock<IStrapiClient>();
+        strapi.Setup(x => x.ReceiveProjectInfoAsync("pid", true)).ReturnsAsync(projectInfo);
+
+        var dynamoDb = new Mock<IDynamoDBContext>();
+        var projectData = new ProjectsInformation { ProjectId = "pid", PoolzBackId = 5 };
+        dynamoDb.Setup(x => x.LoadAsync<ProjectsInformation>("pid", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(projectData);
+
+        var investProvider = new Mock<IInvestProviderService<ContractType>>();
+        investProvider.Setup(x => x.GetUserInvestsQueryAsync(
+                It.IsAny<long>(),
+                ContractType.InvestedProvider,
+                It.IsAny<global::System.Numerics.BigInteger>(),
+                It.IsAny<string>(),
+                null))
+            .ReturnsAsync(new poolz.finance.csharp.contracts.InvestProvider.ContractDefinition.GetUserInvestsOutputDTO { ReturnValue1 = [] });
+
+        var validator = new MyAllocationValidator(strapi.Object, dynamoDb.Object, investProvider.Object);
+        var handler = new MyAllocationHandler();
+        var request = new MyAllocationRequest("pid", new EthereumAddress("0x0000000000000000000000000000000000000123"));
+
+        await validator.ValidateAndThrowAsync(request);
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        Assert.Equal(5m, result.Amount);
+    }
+
 }


### PR DESCRIPTION
## Summary
- support FCFS phases for MyAllocation handler
- compute zero allocation when user already invested
- expose UsedCurrentPhase on request model
- extend base validator
- update tests for new behaviour

## Testing
- `dotnet test InvestProvider.Backend.sln`

------
https://chatgpt.com/codex/tasks/task_e_6860fa57611c8330bf9c51fc679a59b4