### PR TITLE
Introduce context builder and simplify validators

### DIFF
--- a/src/InvestProvider.Backend/Services/DefaultServiceProvider.cs
+++ b/src/InvestProvider.Backend/Services/DefaultServiceProvider.cs
@@ -10,6 +10,8 @@ using InvestProvider.Backend.Services.Web3.Eip712;
 using poolz.finance.csharp.contracts.InvestProvider;
 using InvestProvider.Backend.Services.Web3.Contracts;
 using System.Reflection;
+using MediatR;
+using InvestProvider.Backend.Services.Handlers.ContextBuilders;
 using MediatR.Extensions.FluentValidation.AspNetCore;
 
 namespace InvestProvider.Backend.Services;
@@ -25,6 +27,8 @@ public static class DefaultServiceProvider
 #endif
         .AddMediatR(x => x.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()))
         .AddFluentValidation([Assembly.GetExecutingAssembly()])
+        .AddTransient(typeof(IPipelineBehavior<,>), typeof(ContextBuilderBehavior<,>))
+        .AddTransient(typeof(IRequestContextBuilder<>), typeof(PhaseContextBuilder<>))
         .AddSingleton<IRpcProvider, ChainProvider>()
         .AddSingleton<IChainProvider<ContractType>, ChainProvider>()
         .AddSingleton<IStrapiClient, StrapiClient>()

--- a/src/InvestProvider.Backend/Services/Handlers/AdminCreatePoolzBackId/AdminCreatePoolzBackIdValidator.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/AdminCreatePoolzBackId/AdminCreatePoolzBackIdValidator.cs
@@ -1,7 +1,5 @@
 using FluentValidation;
 using Net.Utils.ErrorHandler.Extensions;
-using InvestProvider.Backend.Services.Strapi;
-using Amazon.DynamoDBv2.DataModel;
 using InvestProvider.Backend.Services.Web3.Contracts;
 using poolz.finance.csharp.contracts.LockDealNFT;
 using InvestProvider.Backend.Services.Handlers.AdminCreatePoolzBackId.Models;
@@ -14,10 +12,8 @@ public class AdminCreatePoolzBackIdValidator : BasePhaseValidator<AdminCreatePoo
     private readonly ILockDealNFTService<ContractType> _lockDealNFT;
 
     public AdminCreatePoolzBackIdValidator(
-        IStrapiClient strapi,
-        IDynamoDBContext dynamoDb,
         ILockDealNFTService<ContractType> lockDealNFT
-    ) : base(strapi, dynamoDb)
+    )
     {
         _lockDealNFT = lockDealNFT;
 
@@ -25,7 +21,7 @@ public class AdminCreatePoolzBackIdValidator : BasePhaseValidator<AdminCreatePoo
 
         RuleFor(x => x)
             .Cascade(CascadeMode.Stop)
-            .Must(NotNullCurrentPhase)
+            .Must(HasCurrentPhase)
             .WithError(Error.NOT_FOUND_ACTIVE_PHASE, x => (new { x.ProjectId }))
             .MustAsync(CorrectProviders)
             .WithError(Error.INVALID_POOL_TYPE);

--- a/src/InvestProvider.Backend/Services/Handlers/AdminWriteAllocation/AdminWriteAllocationValidator.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/AdminWriteAllocation/AdminWriteAllocationValidator.cs
@@ -1,6 +1,4 @@
 using FluentValidation;
-using Amazon.DynamoDBv2.DataModel;
-using InvestProvider.Backend.Services.Strapi;
 using InvestProvider.Backend.Services.Handlers.AdminWriteAllocation.Models;
 
 namespace InvestProvider.Backend.Services.Handlers.AdminWriteAllocation;
@@ -8,8 +6,7 @@ namespace InvestProvider.Backend.Services.Handlers.AdminWriteAllocation;
 public class AdminWriteAllocationValidator : BasePhaseValidator<AdminWriteAllocationRequest>
 {
 
-    public AdminWriteAllocationValidator(IStrapiClient strapi, IDynamoDBContext dynamoDb)
-        : base(strapi, dynamoDb)
+    public AdminWriteAllocationValidator()
     {
         ClassLevelCascadeMode = CascadeMode.Stop;
 

--- a/src/InvestProvider.Backend/Services/Handlers/ContextBuilders/ContextBuilderBehavior.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/ContextBuilders/ContextBuilderBehavior.cs
@@ -1,0 +1,16 @@
+using MediatR;
+
+namespace InvestProvider.Backend.Services.Handlers.ContextBuilders;
+
+public class ContextBuilderBehavior<TRequest, TResponse>(IRequestContextBuilder<TRequest>? builder)
+    : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        if (builder is not null)
+            await builder.BuildAsync(request, cancellationToken);
+
+        return await next();
+    }
+}

--- a/src/InvestProvider.Backend/Services/Handlers/ContextBuilders/IRequestContextBuilder.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/ContextBuilders/IRequestContextBuilder.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InvestProvider.Backend.Services.Handlers.ContextBuilders;
+
+public interface IRequestContextBuilder<in TRequest>
+{
+    Task BuildAsync(TRequest request, CancellationToken cancellationToken);
+}

--- a/src/InvestProvider.Backend/Services/Handlers/ContextBuilders/PhaseContextBuilder.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/ContextBuilders/PhaseContextBuilder.cs
@@ -1,0 +1,33 @@
+using Amazon.DynamoDBv2.DataModel;
+using InvestProvider.Backend.Services.DynamoDb.Models;
+using InvestProvider.Backend.Services.Strapi;
+using InvestProvider.Backend.Services.Validators.Models;
+
+namespace InvestProvider.Backend.Services.Handlers.ContextBuilders;
+
+public class PhaseContextBuilder<T>(IStrapiClient strapi, IDynamoDBContext dynamoDb)
+    : IRequestContextBuilder<T>
+    where T : IExistActivePhase
+{
+    public async Task BuildAsync(T request, CancellationToken cancellationToken)
+    {
+        request.StrapiProjectInfo = await strapi.ReceiveProjectInfoAsync(
+            request.ProjectId,
+            request.FilterPhases);
+
+        if (request is IValidatedDynamoDbProjectInfo validated)
+        {
+            validated.DynamoDbProjectsInfo = await dynamoDb.LoadAsync<ProjectsInformation>(
+                request.ProjectId,
+                cancellationToken);
+        }
+
+        if (request is IWhiteListUser whiteListUser && request.StrapiProjectInfo.CurrentPhase != null)
+        {
+            whiteListUser.WhiteList = await dynamoDb.LoadAsync<WhiteList>(
+                WhiteList.CalculateHashId(request.ProjectId, request.StrapiProjectInfo.CurrentPhase.Start!.Value),
+                whiteListUser.UserAddress.Address,
+                cancellationToken);
+        }
+    }
+}

--- a/src/InvestProvider.Backend/Services/Handlers/MyAllocation/MyAllocationValidator.cs
+++ b/src/InvestProvider.Backend/Services/Handlers/MyAllocation/MyAllocationValidator.cs
@@ -1,20 +1,17 @@
 using FluentValidation;
-using Amazon.DynamoDBv2.DataModel;
 using Net.Utils.ErrorHandler.Extensions;
-using InvestProvider.Backend.Services.Strapi;
 using InvestProvider.Backend.Services.Handlers.MyAllocation.Models;
 
 namespace InvestProvider.Backend.Services.Handlers.MyAllocation;
 
 public class MyAllocationValidator : BasePhaseValidator<MyAllocationRequest>
 {
-    public MyAllocationValidator(IStrapiClient strapi, IDynamoDBContext dynamoDb)
-        : base(strapi, dynamoDb)
+    public MyAllocationValidator()
     {
         ClassLevelCascadeMode = CascadeMode.Stop;
 
         WhiteListPhaseRules(this)
-            .MustAsync(NotNullWhiteListAsync)
+            .Must(HasWhiteList)
             .When(x => x.StrapiProjectInfo.CurrentPhase!.MaxInvest == 0, ApplyConditionTo.CurrentValidator)
             .WithError(Error.NOT_IN_WHITE_LIST, x => new { x.ProjectId, PhaseId = x.StrapiProjectInfo.CurrentPhase!.Id, UserAddress = x.UserAddress.Address });
     }

--- a/tests/InvestProvider.Backend.Tests/Handlers/AdminCreatePoolzBackIdValidatorTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Handlers/AdminCreatePoolzBackIdValidatorTests.cs
@@ -1,19 +1,21 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Threading;
 using System.Threading.Tasks;
-using Amazon.DynamoDBv2.DataModel;
 using Nethereum.RPC.Eth.DTOs;
 using Moq;
 using Xunit;
 using FluentValidation;
 using InvestProvider.Backend.Services.Strapi;
+using Amazon.DynamoDBv2.DataModel;
 using InvestProvider.Backend.Services.Handlers.AdminCreatePoolzBackId;
 using InvestProvider.Backend.Services.Handlers.AdminCreatePoolzBackId.Models;
 using InvestProvider.Backend.Services.Web3.Contracts;
 using poolz.finance.csharp.contracts.LockDealNFT;
 using poolz.finance.csharp.contracts.LockDealNFT.ContractDefinition;
 using InvestProvider.Backend.Tests;
+using InvestProvider.Backend.Services.Handlers.ContextBuilders;
 
 namespace InvestProvider.Backend.Tests.Handlers;
 
@@ -39,7 +41,8 @@ public class AdminCreatePoolzBackIdValidatorTests
                    .ReturnsAsync(fullData);
 
         var dynamoDb = new Mock<IDynamoDBContext>();
-        var validator = new AdminCreatePoolzBackIdValidator(strapi.Object, dynamoDb.Object, lockDealNFT.Object);
+        var builder = new PhaseContextBuilder<AdminCreatePoolzBackIdRequest>(strapi.Object, dynamoDb.Object);
+        var validator = new AdminCreatePoolzBackIdValidator(lockDealNFT.Object);
         var request = new AdminCreatePoolzBackIdRequest
         {
             ProjectId = "pid",
@@ -47,6 +50,7 @@ public class AdminCreatePoolzBackIdValidatorTests
             ChainId = 1
         };
 
+        await builder.BuildAsync(request, CancellationToken.None);
         await validator.ValidateAndThrowAsync(request);
     }
 
@@ -69,7 +73,8 @@ public class AdminCreatePoolzBackIdValidatorTests
                    .ReturnsAsync(fullData);
 
         var dynamoDb = new Mock<IDynamoDBContext>();
-        var validator = new AdminCreatePoolzBackIdValidator(strapi.Object, dynamoDb.Object, lockDealNFT.Object);
+        var builder = new PhaseContextBuilder<AdminCreatePoolzBackIdRequest>(strapi.Object, dynamoDb.Object);
+        var validator = new AdminCreatePoolzBackIdValidator(lockDealNFT.Object);
         var request = new AdminCreatePoolzBackIdRequest
         {
             ProjectId = "pid",
@@ -77,6 +82,7 @@ public class AdminCreatePoolzBackIdValidatorTests
             ChainId = 1
         };
 
+        await builder.BuildAsync(request, CancellationToken.None);
         await Assert.ThrowsAsync<ValidationException>(() => validator.ValidateAndThrowAsync(request));
     }
 }

--- a/tests/InvestProvider.Backend.Tests/Handlers/AdminWriteAllocationValidatorTests.cs
+++ b/tests/InvestProvider.Backend.Tests/Handlers/AdminWriteAllocationValidatorTests.cs
@@ -12,6 +12,7 @@ using InvestProvider.Backend.Services.Handlers.AdminWriteAllocation;
 using InvestProvider.Backend.Services.Handlers.AdminWriteAllocation.Models;
 using Net.Web3.EthereumWallet;
 using FluentValidation;
+using InvestProvider.Backend.Services.Handlers.ContextBuilders;
 
 namespace InvestProvider.Backend.Tests.Handlers;
 
@@ -33,9 +34,11 @@ public class AdminWriteAllocationValidatorTests
         dynamoDb.Setup(x => x.LoadAsync<ProjectsInformation>("pid", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProjectsInformation { ProjectId = "pid", PoolzBackId = 5 });
 
-        var validator = new AdminWriteAllocationValidator(strapi.Object, dynamoDb.Object);
+        var builder = new PhaseContextBuilder<AdminWriteAllocationRequest>(strapi.Object, dynamoDb.Object);
+        var validator = new AdminWriteAllocationValidator();
         var request = new AdminWriteAllocationRequest("pid", "1", new[] { new UserWithAmount(new EthereumAddress("0x0000000000000000000000000000000000000001"), 10) });
 
+        await builder.BuildAsync(request, CancellationToken.None);
         await validator.ValidateAndThrowAsync(request);
     }
 
@@ -53,9 +56,11 @@ public class AdminWriteAllocationValidatorTests
         dynamoDb.Setup(x => x.LoadAsync<ProjectsInformation>("pid", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProjectsInformation { ProjectId = "pid", PoolzBackId = 5 });
 
-        var validator = new AdminWriteAllocationValidator(strapi.Object, dynamoDb.Object);
+        var builder = new PhaseContextBuilder<AdminWriteAllocationRequest>(strapi.Object, dynamoDb.Object);
+        var validator = new AdminWriteAllocationValidator();
         var request = new AdminWriteAllocationRequest("pid", "1", Array.Empty<UserWithAmount>());
 
+        await builder.BuildAsync(request, CancellationToken.None);
         await Assert.ThrowsAsync<ValidationException>(() => validator.ValidateAndThrowAsync(request));
     }
 }


### PR DESCRIPTION
## Summary
- refactor BasePhaseValidator to rely on pre-built context
- add open generic PhaseContextBuilder and MediatR behavior
- remove data loading from validators
- update validator constructors and unit tests
- register new services in DefaultServiceProvider

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_686249e52f2883309ade0520253171a2